### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyscreeze==0.1.28
 opencv-python==4.5.1.48
 PyAutoGUI==0.9.50
 python-imageseach-drov0==1.0.6


### PR DESCRIPTION
Add the specified version of pyscreeze to requirements.txt to prevent automatic installation of the latest version leading to error #133 